### PR TITLE
[BUGFIX] Quick evaluate method should have a different name

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ so if the model can't manage a prediction it will return a `EmptyPrediction` val
 ```
 ...
 val vectorStream: DataStream[Vector] = events.map(event => vectorize(event))
-val predictions: DataStream[Prediction, Vector] = vectorStream.evaluate(reader)
+val predictions: DataStream[Prediction, Vector] = vectorStream.quickEvaluate(reader)
 
 predictions.map(_.target).print()
 

--- a/flink-jpmml-examples/src/main/scala/io/radicalbit/examples/QuickEvaluateKmeans.scala
+++ b/flink-jpmml-examples/src/main/scala/io/radicalbit/examples/QuickEvaluateKmeans.scala
@@ -39,13 +39,14 @@ object QuickEvaluateKmeans extends EnsureParameters {
     val irisDataStream = irisSource(env, None)
 
     //Convert iris to DenseVector
-    val irisToVector = irisDataStream.map(_.toVector)
+    val irisToVector = irisDataStream.map(iris => iris.toVector)
 
     //Load PMML model
     val model = ModelReader(inputModel)
 
-    //Quick evaluate
-    irisToVector.evaluate(model).writeAsText(output)
+    irisToVector
+      .quickEvaluate(model)
+      .writeAsText(output)
 
     env.execute("Quick evaluator Clustering")
   }

--- a/flink-jpmml-scala/src/main/scala/io/radicalbit/flink/pmml/scala/package.scala
+++ b/flink-jpmml-scala/src/main/scala/io/radicalbit/flink/pmml/scala/package.scala
@@ -135,7 +135,7 @@ package object scala {
       * @param modelReader The reader instance coupled to model source path.
       * @return (Prediction, V)
       */
-    def evaluate(modelReader: ModelReader): DataStream[(Prediction, V)] =
+    def quickEvaluate(modelReader: ModelReader): DataStream[(Prediction, V)] =
       new RichDataStream[V](stream).evaluate(modelReader) { (vec, model) =>
         val result: Prediction = model.predict(vec, None)
         (result, vec)

--- a/flink-jpmml-scala/src/test/scala/io/radicalbit/flink/pmml/scala/QuickDataStreamSpec.scala
+++ b/flink-jpmml-scala/src/test/scala/io/radicalbit/flink/pmml/scala/QuickDataStreamSpec.scala
@@ -50,7 +50,7 @@ class QuickDataStreamSpec
     val reader = ModelReader(source getOrElse getPMMLSource(Source.KmeansPmml))
 
     (in: DataStream[Vector]) =>
-      in.evaluate(reader)
+      in.quickEvaluate(reader)
   }
 
   "QuickDataStream" should {


### PR DESCRIPTION
This PR solved the #53 issue. 